### PR TITLE
Keeping TLS-Sessions alive for console mode (-c flag)

### DIFF
--- a/dictcc.py
+++ b/dictcc.py
@@ -11,12 +11,14 @@ from bs4 import BeautifulSoup
 
 _, columns = os.popen('stty size', 'r').read().split()
 
+requests_session = requests.Session()
+
 def request(word, f, t):
     header = {'user-agent': 'Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0'}
     payload = {'s': word}
 
     try:
-        r = requests.get(
+        r = requests_session.get(
                 "https://{}{}.dict.cc/".format(f, t),
                 headers=header,
                 params=payload)


### PR DESCRIPTION
__Current situation:__ For each request, a DNS query is made and a new TLS handshake is performed.
This slows the translation service down immensely. While these circumstances can't be avoided when
exiting the script after each translation query (the default operation), the console mode (`-c`) would profit from a TLS connection that is kept alive.

__Solution:__ Instead of using `requests.get`, which creates new TLS sessions for each call, the concept of
`requests.Session` is used.  

__Result:__ On average, the first request takes `0.8s` (this involves DNS and TLS handshake), while the subsequent calls take `0.2s` to `0.3s`.